### PR TITLE
Switch from device_state_attributes to extra_state_attributes

### DIFF
--- a/custom_components/kodi_media_sensors/entities.py
+++ b/custom_components/kodi_media_sensors/entities.py
@@ -7,7 +7,7 @@ from homeassistant.const import STATE_OFF, STATE_ON, STATE_PROBLEM, STATE_UNKNOW
 from homeassistant.helpers.entity import Entity
 from pykodi import Kodi
 
-from .types import DeviceStateAttrs, KodiConfig
+from .types import ExtraStateAttrs, KodiConfig
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ class KodiRecentlyAddedTVEntity(KodiMediaEntity):
         return "kodi_recently_added_tv"
 
     @property
-    def device_state_attributes(self) -> DeviceStateAttrs:
+    def extra_state_attributes(self) -> ExtraStateAttrs:
         attrs = {}
         card_json = [
             {
@@ -199,7 +199,7 @@ class KodiRecentlyAddedMoviesEntity(KodiMediaEntity):
         return "kodi_recently_added_movies"
 
     @property
-    def device_state_attributes(self) -> DeviceStateAttrs:
+    def extra_state_attributes(self) -> ExtraStateAttrs:
         attrs = {}
         card_json = [
             {

--- a/custom_components/kodi_media_sensors/entity_kodi_media_sensor.py
+++ b/custom_components/kodi_media_sensors/entity_kodi_media_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_PROBLEM,
 )
-from .types import DeviceStateAttrs, KodiConfig
+from .types import ExtraStateAttrs, KodiConfig
 from .const import (
     DOMAIN,
     KEYS,
@@ -187,7 +187,7 @@ class KodiMediaSensorEntity(Entity, ABC):
         return "sensor." + self.unique_id
 
     @property
-    def extra_state_attributes(self) -> DeviceStateAttrs:
+    def extra_state_attributes(self) -> ExtraStateAttrs:
         self.build_attrs()
         return self._attrs
 

--- a/custom_components/kodi_media_sensors/types.py
+++ b/custom_components/kodi_media_sensors/types.py
@@ -3,7 +3,7 @@ from typing import Optional
 from typing_extensions import TypedDict
 
 
-class DeviceStateAttrs(TypedDict):
+class ExtraStateAttrs(TypedDict):
     data: str
 
 


### PR DESCRIPTION
`device_state_attributes` is no longer supported in HA 2022.4. This change will ensure the integration stays working after the next HA release

Fixes #13 