### PR TITLE
Use file as fallback match when there are no IDs.

### DIFF
--- a/custom_components/kodi_media_sensors/entity_kodi_playlist.py
+++ b/custom_components/kodi_media_sensors/entity_kodi_playlist.py
@@ -228,13 +228,18 @@ class KodiPlaylistEntity(KodiMediaSensorEntity):
             self.add_meta("playlist_type", player["type"])
 
             props_item_playing = await self._kodi.get_playing_item_properties(
-                player, []
+                player, ["file"]
             )
             if props_item_playing.get("id") is not None:
                 self.add_meta("currently_playing", props_item_playing["id"])
                 _LOGGER.debug("Currently playing %s", str(props_item_playing["id"]))
             else:
                 _LOGGER.info("No id defined for this item")
+            if props_item_playing.get("file") is not None:
+                self.add_meta("currently_playing_file", props_item_playing["file"])
+                _LOGGER.debug("Currently playing file %s", str(props_item_playing["file"]))
+            else:
+                _LOGGER.info("No file path known for this item")
             self._playlistid = player_id
         else:
             self._playlistid = -1

--- a/custom_components/kodi_media_sensors/entity_kodi_search.py
+++ b/custom_components/kodi_media_sensors/entity_kodi_search.py
@@ -457,12 +457,16 @@ class KodiSearchEntity(KodiMediaSensorEntity):
             )
             if active_playlistid == dest_playlistid:
                 props_item_playing = await self._kodi.get_playing_item_properties(
-                    active_player, []
+                    active_player, ["file"],
                 )
                 active_item_id = props_item_playing.get("id")
+                active_item_file = props_item_playing.get("file")
                 posn = 0
                 for item in dest_playlist:
-                    if item.get("id") == active_item_id:
+                    if item.get("id") is not None and item.get("id") == active_item_id:
+                        current_posn = posn
+                        break
+                    if item.get("file") is not None and item.get("file") == active_item_file:
                         current_posn = posn
                         break
                     else:

--- a/custom_components/kodi_media_sensors/entity_kodi_search.py
+++ b/custom_components/kodi_media_sensors/entity_kodi_search.py
@@ -453,6 +453,7 @@ class KodiSearchEntity(KodiMediaSensorEntity):
                 "Playlist.GetItems",
                 {
                     "playlistid": dest_playlistid,
+                    "properties": ["file"],
                 },
             )
             if active_playlistid == dest_playlistid:


### PR DESCRIPTION
Covers the case of playing stuff with Kodi that isn't at all registered in the database.

Fixes https://github.com/jtbgroup/kodi-media-sensors/issues/22 .